### PR TITLE
use Path::Tiny API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ perl:
     - "5.18"
     - "5.16"
     - "5.14"
-    - "5.12"
-    - "5.10"
 
 before_install:
     - "echo 'user CHIM' > ~/.pause"

--- a/dist.ini
+++ b/dist.ini
@@ -15,7 +15,7 @@ strict                          = 0
 warnings                        = 0
 namespace::autoclean            = 0
 Moose                           = 0
-Dist::Zilla                     = 0
+Dist::Zilla                     = 6.000
 Path::Tiny                      = 0
 
 [Prereqs / TestRequires]

--- a/lib/Dist/Zilla/Plugin/TravisCI/StatusBadge.pm
+++ b/lib/Dist/Zilla/Plugin/TravisCI/StatusBadge.pm
@@ -126,7 +126,7 @@ sub after_build {
             : 'raw'                             # Dist::Zilla pre-5.0
             ;
 
-    Path::Tiny::path( $file )->spew_raw(
+    $file->spew_raw(
         $encoding eq 'raw'
             ? $edited
             : encode( $encoding, $edited )
@@ -214,9 +214,9 @@ sub _try_any_readme {
 
         $self->clear_readme;
 
-        my $file = $self->zilla->root->file( $name );
+        my $file = $self->zilla->root->child( $name );
 
-        if ( -e $file ) {
+        if ( $file->exists ) {
             $self->readme( $name );
             $zillafile = $file;
             last;


### PR DESCRIPTION
At Dist::Zilla 6.000, it excised Path::Class in favor of Path::Tiny.
See https://metacpan.org/source/RJBS/Dist-Zilla-6.009/Changes#L62

Currently warnings are emitted. 
```
❯ perl -MDist::Zilla -E 'say Dist::Zilla->VERSION'
6.009

❯ prove -I. -l t
t/01-basic.t ...... 1/? ->file called on a Dist::Zilla::Path object; this will cease to work in Dist::Zilla v7; downstream code should be updated to use Path::Tiny API, not Path::Class at /home/skaji/src/github.com/Wu-Wu/Dist-Zilla-Plugin-TravisCI-StatusBadge/lib/Dist/Zilla/Plugin/TravisCI/StatusBadge.pm line 217.
t/01-basic.t ...... ok
t/02-distmeta.t ... ->file called on a Dist::Zilla::Path object; this will cease to work in Dist::Zilla v7; downstream code should be updated to use Path::Tiny API, not Path::Class at /home/skaji/src/github.com/Wu-Wu/Dist-Zilla-Plugin-TravisCI-StatusBadge/lib/Dist/Zilla/Plugin/TravisCI/StatusBadge.pm line 217.
t/02-distmeta.t ... ok
t/03-anyreadme.t .. ->file called on a Dist::Zilla::Path object; this will cease to work in Dist::Zilla v7; downstream code should be updated to use Path::Tiny API, not Path::Class at /home/skaji/src/github.com/Wu-Wu/Dist-Zilla-Plugin-TravisCI-StatusBadge/lib/Dist/Zilla/Plugin/TravisCI/StatusBadge.pm line 217.
t/03-anyreadme.t .. ok
All tests successful.
Files=3, Tests=45,  2 wallclock secs ( 0.03 usr  0.01 sys +  2.24 cusr  0.12 csys =  2.40 CPU)
Result: PASS
```

This PR modify Dist-Zilla-Plugin-TravisCI-StatusBadge to use Path::Tiny API.
Fix #3 