### PR TITLE
 Add support for POD READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,15 +67,22 @@ using of the raster representation (PNG).
 
 # SEE ALSO
 
-[https://travis-ci.org](https://travis-ci.org)
+Please see those modules/websites for more information related to this module.
 
-[Dist::Zilla::Plugin::ReadmeAnyFromPod](https://metacpan.org/pod/Dist::Zilla::Plugin::ReadmeAnyFromPod)
+- [https://travis-ci.org](https://travis-ci.org)
+- [Dist::Zilla::Plugin::ReadmeAnyFromPod](https://metacpan.org/pod/Dist::Zilla::Plugin::ReadmeAnyFromPod)
+- [Dist::Zilla::Plugin::GithubMeta](https://metacpan.org/pod/Dist::Zilla::Plugin::GithubMeta)
+- [Dist::Zilla::Role::AfterBuild](https://metacpan.org/pod/Dist::Zilla::Role::AfterBuild)
+- [Dist::Zilla](https://metacpan.org/pod/Dist::Zilla)
 
-[Dist::Zilla::Plugin::GithubMeta](https://metacpan.org/pod/Dist::Zilla::Plugin::GithubMeta)
+# BUGS
 
-[Dist::Zilla::Role::AfterBuild](https://metacpan.org/pod/Dist::Zilla::Role::AfterBuild)
+Please report any bugs or feature requests on the bugtracker website
+[https://github.com/Wu-Wu/Dist-Zilla-Plugin-TravisCI-StatusBadge/issues](https://github.com/Wu-Wu/Dist-Zilla-Plugin-TravisCI-StatusBadge/issues)
 
-[Dist::Zilla](https://metacpan.org/pod/Dist::Zilla)
+When submitting a bug or request, please include a test-file or a
+patch to an existing test-file that illustrates the bug or desired
+feature.
 
 # AUTHOR
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ version 0.007
 
 # DESCRIPTION
 
-Injects the Travis CI `Build status` badge before the **VERSION** header into any form of `README.md`
-file.
+Injects the Travis CI `Build status` badge before the **VERSION** header into any form of `README.[md|pod]` file.
 
 Traget readme might be pointed via option ["readme"](#readme) or guessed by module.
 
@@ -41,10 +40,14 @@ Use [Dist::Zilla::Plugin::ReadmeAnyFromPod](https://metacpan.org/pod/Dist::Zilla
 
 The name of file to inject build status badge. No default value but there is some logic to guess target
 filename. File can be named as `README` or `Readme` and has the one of following extensions: `md`,
-`mkdn` or `markdown`.
+`mkdn`, `markdown` or `pod`.
 
 In case of some name passed via this option, it will be used only if the target file exists otherwise
 will be checked default variations and used first found.
+
+## format
+
+Either `pod` or `markdown`. Optional. When unspecified, format is `pod` if readme has a `.pod` file extension and `markdown` otherwise.
 
 ## user
 

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -26,7 +26,7 @@ describe "TravisCI::StatusBadge" => sub {
                 lives_ok { $tzil->build; };
             };
 
-            it "should not contains a badge" => sub {
+            it "should not contain a badge" => sub {
                 my $content = eval { $tzil->slurp_file( 'source/README.md' ); };
 
                 like(
@@ -49,7 +49,7 @@ describe "TravisCI::StatusBadge" => sub {
                 lives_ok { $tzil->build; };
             };
 
-            it "should not contains a badge" => sub {
+            it "should not contain a badge" => sub {
                 my $content = eval { $tzil->slurp_file( 'source/README.md' ); };
 
                 like(
@@ -72,7 +72,7 @@ describe "TravisCI::StatusBadge" => sub {
                 lives_ok { $tzil->build; };
             };
 
-            it "should not contains a badge" => sub {
+            it "should not contain a badge" => sub {
                 my $content = eval { $tzil->slurp_file( 'source/README.md' ); };
 
                 like(
@@ -102,7 +102,7 @@ describe "TravisCI::StatusBadge" => sub {
             lives_ok { $tzil->build; };
         };
 
-        it "should not contains a badge" => sub {
+        it "should not contain a badge" => sub {
             my $content = eval { $tzil->slurp_file( 'source/README.md' ); };
 
             like(
@@ -131,7 +131,7 @@ describe "TravisCI::StatusBadge" => sub {
                 lives_ok { $tzil->build; };
             };
 
-            it "should contains a badge" => sub {
+            it "should contain a badge" => sub {
                 my $content = eval { $tzil->slurp_file( 'source/README.md' ); };
 
                 like(
@@ -160,7 +160,7 @@ describe "TravisCI::StatusBadge" => sub {
                 lives_ok { $tzil->build; };
             };
 
-            it "should contains a badge" => sub {
+            it "should contain a badge" => sub {
                 my $content = eval { $tzil->slurp_file( 'source/README.md' ); };
 
                 like(
@@ -189,7 +189,7 @@ describe "TravisCI::StatusBadge" => sub {
                 lives_ok { $tzil->build; };
             };
 
-            it "should contains a badge" => sub {
+            it "should contain a badge" => sub {
                 my $content = eval { $tzil->slurp_file( 'source/README.md' ); };
 
                 like(

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -198,6 +198,72 @@ describe "TravisCI::StatusBadge" => sub {
                 );
             };
         };
+
+        describe "when format = markdown" => sub {
+            my ( $tzil_default, $tzil_markdown );
+
+            before all => sub {
+                $tzil_default = t::lib::Builder->tzil(
+                    [
+                        'TravisCI::StatusBadge' => {
+                            repo    => 'p5-John-Doe',
+                            user    => 'johndoe',
+                        }
+                    ]
+                );
+                $tzil_markdown = t::lib::Builder->tzil(
+                    [
+                        'TravisCI::StatusBadge' => {
+                            repo    => 'p5-John-Doe',
+                            user    => 'johndoe',
+                            format  => 'markdown'
+                        }
+                    ]
+                );
+            };
+
+            it "should build dist" => sub {
+                lives_ok { $tzil_markdown->build; };
+                $tzil_default->build;
+            };
+
+            it "should match up with default format" => sub {
+                my $content_default = eval { $tzil_default->slurp_file( 'source/README.md' ); };
+                my $content_markdown = eval { $tzil_markdown->slurp_file( 'source/README.md' ); };
+
+                is $content_default, $content_markdown;
+            };
+        };
+
+        describe "when format = pod" => sub {
+            my ( $tzil );
+
+            before all => sub {
+                $tzil = t::lib::Builder->tzil_for_pod(
+                    [
+                        'TravisCI::StatusBadge' => {
+                            repo    => 'p5-John-Doe',
+                            user    => 'johndoe',
+                            format  => 'pod',
+                            readme  => 'README',
+                        }
+                    ]
+                );
+            };
+
+            it "should build dist" => sub {
+                lives_ok { $tzil->build; };
+            };
+
+            it "should contain a badge" => sub {
+                my $content = eval { $tzil->slurp_file( 'source/README' ); };
+
+                like(
+                    $content,
+                    qr{\Q<img alt="Build Status"},
+                );
+            };
+        };
     };
 };
 

--- a/t/02-distmeta.t
+++ b/t/02-distmeta.t
@@ -28,7 +28,7 @@ describe "TravisCI::StatusBadge" => sub {
                 lives_ok { $tzil->build; };
             };
 
-            it "should contains a badge" => sub {
+            it "should contain a badge" => sub {
                 my $content = eval { $tzil->slurp_file( 'source/README.md' ); };
 
                 like(
@@ -57,7 +57,7 @@ describe "TravisCI::StatusBadge" => sub {
                 lives_ok { $tzil->build; };
             };
 
-            it "should contains a badge" => sub {
+            it "should contain a badge" => sub {
                 my $content = eval { $tzil->slurp_file( 'source/README.md' ); };
 
                 like(
@@ -86,7 +86,7 @@ describe "TravisCI::StatusBadge" => sub {
                 lives_ok { $tzil->build; };
             };
 
-            it "should contains a badge" => sub {
+            it "should contain a badge" => sub {
                 my $content = eval { $tzil->slurp_file( 'source/README.md' ); };
 
                 like(
@@ -117,7 +117,7 @@ describe "TravisCI::StatusBadge" => sub {
                 lives_ok { $tzil->build; };
             };
 
-            it "should contains a badge" => sub {
+            it "should contain a badge" => sub {
                 my $content = eval { $tzil->slurp_file( 'source/README.md' ); };
 
                 like(
@@ -146,7 +146,7 @@ describe "TravisCI::StatusBadge" => sub {
                 lives_ok { $tzil->build; };
             };
 
-            it "should contains a badge" => sub {
+            it "should contain a badge" => sub {
                 my $content = eval { $tzil->slurp_file( 'source/README.md' ); };
 
                 like(
@@ -173,7 +173,7 @@ describe "TravisCI::StatusBadge" => sub {
                 lives_ok { $tzil->build; };
             };
 
-            it "should not contains a badge" => sub {
+            it "should not contain a badge" => sub {
                 my $content = eval { $tzil->slurp_file( 'source/README.md' ); };
 
                 like(
@@ -202,7 +202,7 @@ describe "TravisCI::StatusBadge" => sub {
                 lives_ok { $tzil->build; };
             };
 
-            it "should not contains a badge" => sub {
+            it "should not contain a badge" => sub {
                 my $content = eval { $tzil->slurp_file( 'source/README.md' ); };
 
                 like(

--- a/t/03-anyreadme.t
+++ b/t/03-anyreadme.t
@@ -35,7 +35,7 @@ describe "TravisCI::StatusBadge" => sub {
             lives_ok { $tzil->build; };
         };
 
-        it "should contains a badge" => sub {
+        it "should contain a badge" => sub {
             my $content = eval { $tzil->slurp_file( 'source/README.mkdn' ); };
 
             like(
@@ -58,7 +58,7 @@ describe "TravisCI::StatusBadge" => sub {
             lives_ok { $tzil->build; };
         };
 
-        it "should contains a badge" => sub {
+        it "should contain a badge" => sub {
             my $content = eval { $tzil->slurp_file( 'source/README.markdown' ); };
 
             like(
@@ -81,7 +81,7 @@ describe "TravisCI::StatusBadge" => sub {
             lives_ok { $tzil->build; };
         };
 
-        it "should contains a badge" => sub {
+        it "should contain a badge" => sub {
             my $content = eval { $tzil->slurp_file( 'source/README.md' ); };
 
             like(
@@ -104,7 +104,7 @@ describe "TravisCI::StatusBadge" => sub {
             lives_ok { $tzil->build; };
         };
 
-        it "should contains a badge" => sub {
+        it "should contain a badge" => sub {
             my $content = eval { $tzil->slurp_file( 'source/Readme.mkdn' ); };
 
             like(
@@ -127,7 +127,7 @@ describe "TravisCI::StatusBadge" => sub {
             lives_ok { $tzil->build; };
         };
 
-        it "should contains a badge" => sub {
+        it "should contain a badge" => sub {
             my $content = eval { $tzil->slurp_file( 'source/Readme.markdown' ); };
 
             like(
@@ -150,7 +150,7 @@ describe "TravisCI::StatusBadge" => sub {
             lives_ok { $tzil->build; };
         };
 
-        it "should contains a badge" => sub {
+        it "should contain a badge" => sub {
             my $content = eval { $tzil->slurp_file( 'source/Readme.md' ); };
 
             like(
@@ -173,7 +173,7 @@ describe "TravisCI::StatusBadge" => sub {
             lives_ok { $tzil->build; };
         };
 
-        it "should not contains a badge" => sub {
+        it "should not contain a badge" => sub {
             my $content = eval { $tzil->slurp_file( 'source/README1.md' ); };
 
             like(
@@ -196,7 +196,7 @@ describe "TravisCI::StatusBadge" => sub {
             lives_ok { $tzil->build; };
         };
 
-        it "should not contains a badge" => sub {
+        it "should not contain a badge" => sub {
             my $content = eval { $tzil->slurp_file( 'source/README.mdx' ); };
 
             like(

--- a/t/03-anyreadme.t
+++ b/t/03-anyreadme.t
@@ -24,7 +24,7 @@ describe "TravisCI::StatusBadge" => sub {
 
     describe "for README.mkdn" => sub {
         before all => sub {
-            $tzil = t::lib::Builder->tzil_for( 'README.mkdn', $config );
+            $tzil = t::lib::Builder->tzil_for( 'README.mkdn', 'markdown', $config );
 
             $tzil->expects( 'distmeta' )
                 ->returns( spoof_distmeta( 'Wu-Wu-x' ) )
@@ -47,7 +47,7 @@ describe "TravisCI::StatusBadge" => sub {
 
     describe "for README.markdown" => sub {
         before all => sub {
-            $tzil = t::lib::Builder->tzil_for( 'README.markdown', $config );
+            $tzil = t::lib::Builder->tzil_for( 'README.markdown', 'markdown', $config );
 
             $tzil->expects( 'distmeta' )
                 ->returns( spoof_distmeta( 'Wu-Wu-y' ) )
@@ -70,7 +70,7 @@ describe "TravisCI::StatusBadge" => sub {
 
     describe "for README.md" => sub {
         before all => sub {
-            $tzil = t::lib::Builder->tzil_for( 'README.md', $config );
+            $tzil = t::lib::Builder->tzil_for( 'README.md', 'markdown', $config );
 
             $tzil->expects( 'distmeta' )
                 ->returns( spoof_distmeta( 'Wu-Wu-z' ) )
@@ -93,7 +93,7 @@ describe "TravisCI::StatusBadge" => sub {
 
     describe "for Readme.mkdn" => sub {
         before all => sub {
-            $tzil = t::lib::Builder->tzil_for( 'Readme.mkdn', $config );
+            $tzil = t::lib::Builder->tzil_for( 'Readme.mkdn', 'markdown', $config );
 
             $tzil->expects( 'distmeta' )
                 ->returns( spoof_distmeta( 'Wu-Wu-a' ) )
@@ -116,7 +116,7 @@ describe "TravisCI::StatusBadge" => sub {
 
     describe "for Readme.markdown" => sub {
         before all => sub {
-            $tzil = t::lib::Builder->tzil_for( 'Readme.markdown', $config );
+            $tzil = t::lib::Builder->tzil_for( 'Readme.markdown', 'markdown', $config );
 
             $tzil->expects( 'distmeta' )
                 ->returns( spoof_distmeta( 'Wu-Wu-b' ) )
@@ -139,7 +139,7 @@ describe "TravisCI::StatusBadge" => sub {
 
     describe "for Readme.md" => sub {
         before all => sub {
-            $tzil = t::lib::Builder->tzil_for( 'Readme.md', $config );
+            $tzil = t::lib::Builder->tzil_for( 'Readme.md', 'markdown', $config );
 
             $tzil->expects( 'distmeta' )
                 ->returns( spoof_distmeta( 'Wu-Wu-c' ) )
@@ -162,7 +162,7 @@ describe "TravisCI::StatusBadge" => sub {
 
     describe "for README1.md" => sub {
         before all => sub {
-            $tzil = t::lib::Builder->tzil_for( 'README1.md', $config );
+            $tzil = t::lib::Builder->tzil_for( 'README1.md', 'markdown', $config );
 
             $tzil->expects( 'distmeta' )
                 ->returns( spoof_distmeta( 'Wu-Wu-d' ) )
@@ -183,9 +183,55 @@ describe "TravisCI::StatusBadge" => sub {
         };
     };
 
+    describe "for README.pod" => sub {
+        before all => sub {
+            $tzil = t::lib::Builder->tzil_for( 'README.pod', 'pod', $config );
+
+            $tzil->expects( 'distmeta' )
+                ->returns( spoof_distmeta( 'Wu-Wu-c' ) )
+                ->at_least( 1 );
+        };
+
+        it "should build dist" => sub {
+            lives_ok { $tzil->build; };
+        };
+
+        it "should contain a badge" => sub {
+            my $content = eval { $tzil->slurp_file( 'source/README.pod' ); };
+
+            like(
+                $content,
+                qr{\Q<img alt="Build Status" src="https://travis-ci.org/Wu-Wu-c/p5-Foo-Bar.png?branch=master"\E},
+            );
+        };
+    };
+
+    describe "for README1.pod" => sub {
+        before all => sub {
+            $tzil = t::lib::Builder->tzil_for( 'README1.pod', 'pod', $config );
+
+            $tzil->expects( 'distmeta' )
+                ->returns( spoof_distmeta( 'Wu-Wu-d' ) )
+                ->at_least( 1 );
+        };
+
+        it "should build dist" => sub {
+            lives_ok { $tzil->build; };
+        };
+
+        it "should not contain a badge" => sub {
+            my $content = eval { $tzil->slurp_file( 'source/README1.pod' ); };
+
+            like(
+                $content,
+                qr{[^\Q<img alt="Build Status"\E]},
+            );
+        };
+    };
+
     describe "for README.mdx" => sub {
         before all => sub {
-            $tzil = t::lib::Builder->tzil_for( 'README.mdx', $config );
+            $tzil = t::lib::Builder->tzil_for( 'README.mdx', 'markdown', $config );
 
             $tzil->expects( 'distmeta' )
                 ->returns( spoof_distmeta( 'Wu-Wu-e' ) )

--- a/t/lib/Builder.pm
+++ b/t/lib/Builder.pm
@@ -24,11 +24,43 @@ Aliquam conubia sodales malesuada scelerisque, faucibus orci dapibus senectus eg
 
 MD_SAMPLE
 
+use constant POD_SAMPLE => <<"POD_SAMPLE";
+=pod
+
+=head1 NAME
+
+Foo::Bar - Foo and Bar
+
+=head1 VERSION
+
+version 0.001
+
+=head1 SYNOPSIS
+
+    use Foo::Bar;
+
+=head1 DESCRIPTION
+
+Tellus proin aptent mattis vel pulvinar, et dui netus tellus.
+
+Habitant ipsum nisl ad feugiat orci suscipit et sodales sodales.
+
+Aliquam conubia sodales malesuada scelerisque, faucibus orci dapibus senectus eget.
+
+POD_SAMPLE
+
 # README.md's builder
 sub tzil {
     shift;
 
-    get_builder( 'README.md', @_ );
+    get_builder( 'README.md', 'markdown', @_ );
+}
+
+# README in POD syntax builder
+sub tzil_for_pod {
+    shift;
+
+    get_builder( 'README', 'pod', @_ );
 }
 
 # any readme builder
@@ -39,13 +71,16 @@ sub tzil_for {
 }
 
 sub get_builder {
-    my ( $filename, @params ) = @_;
+    ( my $filename, $_, my @params ) = @_;
+    my $sample = /markdown/i ? MD_SAMPLE
+               : /pod/i      ? POD_SAMPLE
+               :               die("Unknown sample type");
 
     Builder->from_config(
         { dist_root => 'corpus/dist/DZT' },
         {
             add_files => {
-                'source/' . $filename   => MD_SAMPLE,
+                'source/' . $filename   => $sample,
                 'source/dist.ini'       => simple_ini( 'GatherDir', @params ),
             }
         },


### PR DESCRIPTION
POD READMEs are detected by their .pod file extension.
Alternatively, the user may specify `format = pod` in the dist.ini.

The other commit fixes some typos.